### PR TITLE
Refactor run.sh to external script

### DIFF
--- a/calculate.py
+++ b/calculate.py
@@ -1,0 +1,10 @@
+def calculate(days: float, miles: float, receipts: float) -> float:
+    """Compute the reimbursement amount."""
+    BASE_PER_DIEM = 50.0
+    RATE_FIRST_600 = 0.35
+    RATE_AFTER_600 = 0.20
+    RECEIPT_WEIGHT = 0.80
+
+    mileage = RATE_FIRST_600 * min(miles, 600) + RATE_AFTER_600 * max(miles - 600, 0)
+    amount = RECEIPT_WEIGHT * receipts + BASE_PER_DIEM * days + mileage
+    return amount

--- a/run.py
+++ b/run.py
@@ -1,0 +1,24 @@
+import sys
+from calculate import calculate
+
+
+def main():
+    if len(sys.argv) != 4:
+        sys.stderr.write(
+            "Usage: run.py <trip_duration_days> <miles_traveled> <total_receipts_amount>\n"
+        )
+        sys.exit(1)
+    try:
+        days = float(sys.argv[1])
+        miles = float(sys.argv[2])
+        receipts = float(sys.argv[3])
+    except ValueError:
+        sys.stderr.write("Error: all parameters must be numeric\n")
+        sys.exit(1)
+
+    result = calculate(days, miles, receipts)
+    print(f"{result:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run.sh
+++ b/run.sh
@@ -1,15 +1,2 @@
-python3 - <<'PY' "$@"
-import sys
-
-days, miles, receipts = map(float, sys.argv[1:4])
-
-BASE_PER_DIEM   = 50.0
-RATE_FIRST_600  = 0.35
-RATE_AFTER_600  = 0.20
-RECEIPT_WEIGHT  = 0.80
-
-mileage = RATE_FIRST_600 * min(miles, 600) + RATE_AFTER_600 * max(miles - 600, 0)
-amount  = RECEIPT_WEIGHT * receipts + BASE_PER_DIEM * days + mileage
-
-print(f"{amount:.2f}")
-PY
+#!/bin/bash
+python3 run.py "$@"


### PR DESCRIPTION
## Summary
- simplify `run.sh` so it just launches Python
- expose a new `calculate` helper in `calculate.py`
- add `run.py` to parse CLI args and invoke `calculate`